### PR TITLE
Automatically fix malformed ticket URLs, and improve error message

### DIFF
--- a/EED_Ticketing.module.php
+++ b/EED_Ticketing.module.php
@@ -570,14 +570,8 @@ class EED_Ticketing extends EED_Messages
         if (empty($token)) {
             throw new EE_Error(
                 esc_html__(
-                    'Whoa! Dude! Something went wrong and we\'re unable to display your ticket. Please contact the website administrator and inform them that the ticket URL is invalid.',
+                    'Something went wrong and we\'re unable to display your ticket. Please contact the website administrator and inform them that the ticket URL is invalid.',
                     'event_espresso'
-                )
-                . '<br/>'
-                . sprintf(
-                    esc_html__('If you\'re comfortable with a little do-it-yourself repairing, you could try changing any "%1$s"s in the address bar to simply "%2$s".', 'event_espresso'),
-                    '&ampamp;',
-                    '&'
                 )
             );
         }

--- a/EED_Ticketing.module.php
+++ b/EED_Ticketing.module.php
@@ -564,9 +564,16 @@ class EED_Ticketing extends EED_Messages
         if (empty($token)) {
             throw new EE_Error(
                 esc_html__(
-                    'The request for the "ee-txn-tickets-url" route has a malformed url.',
+                    'Whoa! Dude! Something went wrong and we\'re unable to display your ticket. Please contact the website administrator and inform them that the ticket URL is invalid.',
                     'event_espresso'
                 )
+                . '<br/>'
+                . sprintf(
+                    esc_html__('If you\'re comfortable with a little do-it-yourself repairing, you could try changing any "%1$s"s in the address bar to simply "%2$s".', 'event_espresso'),
+                    '&ampamp;',
+                    '&'
+                )
+
             );
         }
 

--- a/EED_Ticketing.module.php
+++ b/EED_Ticketing.module.php
@@ -562,6 +562,12 @@ class EED_Ticketing extends EED_Messages
 
         // verify the needed params are present.
         if (empty($token)) {
+            // are they using &amp; instead of &? if so, maybe we can fix the querystring enough to find the token
+            $query_args = array();
+            parse_str(str_replace(array('&amp;', '&amp'), '&', $_SERVER['QUERY_STRING']), $query_args);
+            $token = isset($query_args['token']) ? $query_args['token'] : '';
+        }
+        if (empty($token)) {
             throw new EE_Error(
                 esc_html__(
                     'Whoa! Dude! Something went wrong and we\'re unable to display your ticket. Please contact the website administrator and inform them that the ticket URL is invalid.',

--- a/EED_Ticketing.module.php
+++ b/EED_Ticketing.module.php
@@ -570,7 +570,7 @@ class EED_Ticketing extends EED_Messages
         if (empty($token)) {
             throw new EE_Error(
                 esc_html__(
-                    'Something went wrong and we\'re unable to display your ticket. Please contact the website administrator and inform them that the ticket URL is invalid.',
+                    'Something went wrong and we\'re unable to display your ticket. Please contact the event organizer to get your ticket.',
                     'event_espresso'
                 )
             );

--- a/EED_Ticketing.module.php
+++ b/EED_Ticketing.module.php
@@ -564,7 +564,14 @@ class EED_Ticketing extends EED_Messages
         if (empty($token)) {
             // are they using &amp; instead of &? if so, maybe we can fix the querystring enough to find the token
             $query_args = array();
-            parse_str(str_replace(array('&amp;', '&amp'), '&', $_SERVER['QUERY_STRING']), $query_args);
+            parse_str(
+                str_replace(
+                    array('&amp;', '&amp'),
+                    '&',
+                    isset($_SERVER['QUERY_STRING']) ? $_SERVER['QUERY_STRING'] : ''
+                ),
+                $query_args
+            );
             $token = isset($query_args['token']) ? $query_args['token'] : '';
         }
         if (empty($token)) {

--- a/EED_Ticketing.module.php
+++ b/EED_Ticketing.module.php
@@ -573,7 +573,6 @@ class EED_Ticketing extends EED_Messages
                     '&ampamp;',
                     '&'
                 )
-
             );
         }
 


### PR DESCRIPTION
See https://github.com/eventespresso/eea-ticketing/issues/3



<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Sometimes folks wound up with malfomed ticket URLs (see https://github.com/eventespresso/eea-ticketing/issues/3#issuecomment-404956901 for the theory on how those happened, but the main takeaway: they had bad URLs, but the problem hopefully won't come up more). When this happened, they'd visit the page and see a message that's pretty hard for the average joe to understand. 
This attempts to fix the URL automatically by changing all `&amp;`s in the querystring into `&`s. 
If that doesn't work, we give a (hopefully) more user-friendly message.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [  ] Register and pay for an event. In the ticket message you receive, click on the link to print tickets. Replace the "&"s with `&amp;`s and try again. You should get a helpful error message. 

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
