### PR TITLE
Fix barcode not rendering in ios (fixes #7)

### DIFF
--- a/core/shortcodes/assets/ee-ticketing.js
+++ b/core/shortcodes/assets/ee-ticketing.js
@@ -1,4 +1,8 @@
 jQuery(document).ready(function($) {
+	// browser detection
+	var iOS = !! navigator.platform &&
+		/iPad|iPhone|iPod/.test( navigator.platform );
+
 	//qrcodes
 	var qrcode_val, dimensions, qrcolor, qrmode, qrlabel;
 	$('.ee-qr-code').each( function(i) {
@@ -21,7 +25,7 @@ jQuery(document).ready(function($) {
 		bc_settings.bgColor = $('.ee-barcode-bgcolor', this ).text();
 		bc_settings.fontSize = parseInt( $('.ee-barcode-fsize', this ).text(), 10 );
 		bc_settings.output= $('.ee-barcode-output-type', this ).text();
-		bc_type = $('.ee-barcode-type', this ).text();
+		bc_type = iOS ? 'css' : $('.ee-barcode-type', this ).text();
 		container.barcode( { code: barcode_val }, bc_type, bc_settings );
 	});
 

--- a/core/shortcodes/assets/ee-ticketing.js
+++ b/core/shortcodes/assets/ee-ticketing.js
@@ -2,8 +2,7 @@ jQuery(document).ready(function($) {
 	// browser detection
 	var iOS = !! navigator.platform &&
 		/iPad|iPhone|iPod/.test( navigator.platform );
-	console.log( iOS );
-	console.log( navigator.platform );
+
 	//qrcodes
 	var qrcode_val, dimensions, qrcolor, qrmode, qrlabel;
 	$('.ee-qr-code').each( function(i) {
@@ -25,8 +24,8 @@ jQuery(document).ready(function($) {
 		bc_settings.color = $('.ee-barcode-color', this ).text();
 		bc_settings.bgColor = $('.ee-barcode-bgcolor', this ).text();
 		bc_settings.fontSize = parseInt( $('.ee-barcode-fsize', this ).text(), 10 );
-		bc_settings.output= $('.ee-barcode-output-type', this ).text();
-		bc_type = iOS ? 'css' : $('.ee-barcode-type', this ).text();
+		bc_settings.output= iOS ? 'css' : $('.ee-barcode-output-type', this ).text();
+		bc_type = $('.ee-barcode-type', this ).text();
 		container.barcode( { code: barcode_val }, bc_type, bc_settings );
 	});
 

--- a/core/shortcodes/assets/ee-ticketing.js
+++ b/core/shortcodes/assets/ee-ticketing.js
@@ -2,7 +2,8 @@ jQuery(document).ready(function($) {
 	// browser detection
 	var iOS = !! navigator.platform &&
 		/iPad|iPhone|iPod/.test( navigator.platform );
-
+	console.log( iOS );
+	console.log( navigator.platform );
 	//qrcodes
 	var qrcode_val, dimensions, qrcolor, qrmode, qrlabel;
 	$('.ee-qr-code').each( function(i) {


### PR DESCRIPTION
## Problem this Pull Request solves

See #7 for context.  This pull adds device detection and uses `css` as the output type when the device detected is an iOs device.

## How has this been tested

* [x] Verify barcode loads in safari as expected (I used Safari dev tools to connect my iPhone to my desktop safari and verified that the barcode loaded in iOs safari).
* [x] Verify that non iOs devices use whatever output type is set in the shortcode.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
