### PR TITLE
Fix i18n strings where tags were displayed in Shortcodes documentation

### DIFF
--- a/domain/services/messages/RegisterCustomShortcodes.php
+++ b/domain/services/messages/RegisterCustomShortcodes.php
@@ -143,15 +143,27 @@ class RegisterCustomShortcodes
              )
              . '</li>'
              . '<li><strong>output_type</strong>:'
-             . esc_html__(
-                 'Used to set the output type for the generated barcode (default is svg).  Can be either svg, canvas, bmp, or css. <em>Note: Some output types don\'t print well depending on the browser.  Make sure you verify printability.</em> [BARC0DE_* output_type=bmp]',
-                 'event_espresso'
+             . sprintf(
+                 /* translators: 1: emphasis tag, 2: close emphasis tag, 3: shortcode example */
+                 esc_html__(
+                     'Used to set the output type for the generated barcode (default is svg). Can be either svg, canvas, bmp, or css. %1$sNote: Some output types don\'t print well depending on the browser. Make sure you verify printability.%2$s %3$s',
+                     'event_espresso'
+                 ),
+                 '<em>',
+                 '</em>',
+                 '<code>[BARC0DE_* output_type=bmp]</code>'
              )
              . '</li>'
              . '<li><strong>generate_for</strong>:'
-             . esc_html__(
-                 'This allows you to set what gets used to generate the barcode. When the barcode is scanned this is the value that will be returned. There are two options: "long_code", which is the equivalent to <em>reg_url_lnk</em> value for the registration; or "short_code", which is the equivalent to the <em>reg_code</em> value for the registration.  The default is "short_code". <code>[BARCODE_* generate_for=short_code]</code>',
-                 'event_espresso'
+             . sprintf(
+                 /* translators: 1: emphasis tag, 2: close emphasis tag, 3: shortcode example */
+                 esc_html__(
+                     'This allows you to set what gets used to generate the barcode. When the barcode is scanned this is the value that will be returned. There are two options: "long_code", which is the equivalent to %1$sreg_url_link%2$s value for the registration; or "short_code", which is the equivalent to the %1$sreg_code%2$s value for the registration. The default is "short_code". %3$s',
+                     'event_espresso'
+                 ),
+                 '<em>',
+                 '</em>',
+                 '<code>[BARCODE_* generate_for=short_code]</code>'
              )
              . '</ul></p>';
         }


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
There are html tags in the shortcode documentation.
![Screen Shot 2019-06-26 at 12 24 16 PM](https://user-images.githubusercontent.com/891156/60197501-7e271c80-980d-11e9-9080-7a9e48917cbf.png)


## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
View the Ticket editor's Help > Shortcodes page and compare with the above screenshot. No html tags should be displayed.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
