### PR TITLE
Feature: implement custom qr code shortcode (fixes #8)

### DIFF
--- a/core/shortcodes/assets/ee-ticketing.js
+++ b/core/shortcodes/assets/ee-ticketing.js
@@ -1,13 +1,15 @@
 jQuery(document).ready(function($) {
 	//qrcodes
-	var qrcode_val, dimensions, qrcolor, qrmode, qrlabel;
 	$('.ee-qr-code').each( function(i) {
-		qrcode_val = $('.ee-qrcode-reg_url_link', this).text();
-		dimensions = parseInt( $('.ee-qrcode-dimensions', this).text(), 10 );
-		qrcolor = $('.ee-qrcode-color', this).text();
-		qrmode = parseInt( $('.ee-qrcode-mode', this).text(), 10);
-		qrlabel = $('.ee-qrcode-label', this).text();
-		$(this).qrcode( {size:dimensions, text: qrcode_val, fill: qrcolor, mode: qrmode, label : qrlabel } );
+		var data = $( this ).data();
+		var config = {
+			size: parseInt( data.dimensions, 10 ),
+			text: data.content,
+			fill: data.color,
+			mode: parseInt( data.mode, 10),
+			label: data.label
+		};
+		$(this).qrcode( config );
 	});
 
 	//barcodes


### PR DESCRIPTION
## Problem this Pull Request solves

**NOTE**: This pull will also require some changes to ee core (see [this branch](https://github.com/eventespresso/event-espresso-core/tree/FET/custom-qr-code-requirements) and in particular [this commit](https://github.com/eventespresso/event-espresso-core/commit/5bec305a099048c5c4aa6fbc6d534ea5ebc79e2d))

See #8 for details.  This is a WIP pull that I haven't completed yet.  Currently it:

- Adds the `[CUSTOM_QR_CODE_*]` shortcode php side.
- Modifies the way qr code data is transformed via javascript by embedding it as data properties instead of hidden text in span tags.

I haven't been able to get this to work yet as there are issues with how the main parser library works and nesting issues with shortcodes _inside_ a shortcode (eg. `[CUSTOM_QR_CODE_ content=[RECIPIENT_FNAME]]`).  I'm not sure this is even doable but I did give it a good go while I was working on it.  

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
