### PR TITLE
avoid page breaks if enough room to include a whole ticket

### DIFF
--- a/core/messages/templates/variations/html_ticketing_print_default.css
+++ b/core/messages/templates/variations/html_ticketing_print_default.css
@@ -1,3 +1,9 @@
 .outside:not(:first-of-type) {
-	page-break-before:always
+	page-break-before:auto;
+	break-before: auto;
+}
+
+.outside {
+	page-break-inside: avoid;
+	break-inside: avoid;
 }


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
This PR solves the problem of wasted paper by allowing more than one ticket to be printed on a page if there's enough room for more than one ticket. All while avoiding "splitting up" a ticket into two parts between two pages
## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Open a transactions tickets page (with multiple tickets) in Firefox, print preview (Mac OS)

Note: You'll likely need to remove some of the default ticket template content because the default ticket template generally uses more than 50% of a full page.