### PR TITLE
Add a title attribute to the ticket linked added to the My Events output

### DIFF
--- a/EED_Ticketing_WPUser_Integration.module.php
+++ b/EED_Ticketing_WPUser_Integration.module.php
@@ -66,8 +66,10 @@ class EED_Ticketing_WPUser_Integration extends EED_Module
             return $actions;
         }
         $actions = (array) $actions;
-        $actions['ticket'] = '<a aria-label="' . esc_html__('Link to view ticket', 'event_espresso') . '"'
-                . ' href="' . EED_Ticketing::getTicketUrl($registration) . '">'
+        $link_to_view_ticket_text = esc_html__('Link to view ticket', 'event_espresso');
+        $actions['ticket'] = '<a aria-label="' . $link_to_view_ticket_text
+                . '" title="' . $link_to_view_ticket_text
+                . '" href="' . EED_Ticketing::getTicketUrl($registration) . '">'
                 . '<span class="dashicons dashicons-tickets-alt ee-icon-size-18"></span></a>';
         return $actions;
     }


### PR DESCRIPTION
See: https://eventespresso.com/topic/wp-user-integration-settings/?view=all#post-309458

And this: https://www.screencast.com/t/ZO0X9F25eng

Hovering over the ticket icon on the my events section doesn't show a tooltip as no title has been set.

## How has this been tested
Load up the my events section from the User integration add-on.

Approved registrations should show the ticket link in the actions, hover over that icon.

With master, no tooltip, with this branch you should see 'Link to view ticket'.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
